### PR TITLE
fix showing null values from OPTIONAL queries

### DIFF
--- a/ipython_sparql/sparql.py
+++ b/ipython_sparql/sparql.py
@@ -153,7 +153,10 @@ def prepare_json_to_tabular(result):
     for data in result['results']['bindings']:
         row = []
         for var in vars:
-            d = data[var]['value']
+            if var in data:
+                d = data[var]['value']
+            else:
+                d = None
             row.append(d)
         table.append(row)
 

--- a/ipython_sparql/tests/magic_sparql_tests.py
+++ b/ipython_sparql/tests/magic_sparql_tests.py
@@ -62,6 +62,31 @@ class TestSparqlWrapperClient(unittest.TestCase):
 
         self.assertEquals(result, expected)
 
+    def test_sparql_query_result_select_optinoal_null_values(self):
+        query = \
+        '''
+        PREFIX : <http://dbpedia.org/resource/>
+        PREFIX dbo: <http://dbpedia.org/ontology/>
+
+        SELECT DISTINCT ?Nombre ?Capital
+        WHERE 
+        { 
+            :Portugal rdf:type yago:WikicatCountriesInEurope .
+            :Portugal foaf:name ?Nombre .
+            OPTIONAL { :Portugal dbo:capital ?Capital }
+        }
+        '''
+
+        expected = {'head': {'link': [], 'vars': ['Nombre', 'Capital']},
+                    'results': {'bindings': 
+                    [{'Nombre': {'type': 'literal', 'value': 'Portugal', 'xml:lang': 'en'}}],
+                    'distinct': False,
+                    'ordered': True}}
+
+        result = self.sparql_client.query(self.endpoint, query).results()
+
+        self.assertEquals(result, expected)
+
 
 """
 def suite():


### PR DESCRIPTION
There was a problem when visualizing results from queries that uses OPTIONAL. 

<img width="1126" alt="screen shot 2017-09-21 at 3 39 29 pm" src="https://user-images.githubusercontent.com/15633182/30712697-3e0b0046-9ee3-11e7-9d02-249cc5adfe63.png">

I just added two lines to check for the existence of a value. If the value doesn't exist in the dictionary then a None is added.